### PR TITLE
fix(security): enforce HTTPS for API calls

### DIFF
--- a/smspartnerapi.php
+++ b/smspartnerapi.php
@@ -2,7 +2,7 @@
 
 class SMSPartnerAPI
 {
-	const BASE_URL = 'http://api.smspartner.fr/v1/';
+	const BASE_URL = 'https://api.smspartner.fr/v1/';
 	public $debug;
 
 	public function __construct($debug = false)


### PR DESCRIPTION
Hi,

I just updated the API endpoint URLs from HTTP to HTTPS to ensure secure communication. This change enhances the security of data transmission and protects against man-in-the-middle attacks.